### PR TITLE
@ash => Adds support for showing multiple failing expectations in a test case

### DIFF
--- a/lib/second_curtain/parser.rb
+++ b/lib/second_curtain/parser.rb
@@ -20,8 +20,7 @@ class Parser
         test_case = XcodeTestCase.test_case_from_line(line)
         latest_test_suite.test_cases.push test_case unless test_case == nil
       elsif line.include?("' failed (")
-        command = latest_test_suite.latest_test_case.latest_command
-        if command != nil
+        latest_test_suite.latest_test_case.commands.each do |command|
           command.fails = true
         end
       end


### PR DESCRIPTION
This brings it in line with Snapshots. See #28 
