### PR TITLE
Fix for #12

### DIFF
--- a/lib/second_curtain/path_utils.rb
+++ b/lib/second_curtain/path_utils.rb
@@ -1,0 +1,21 @@
+class PathUtils
+
+  # Returns a path  composed of components, without leading and trailing slashes
+  def self.pathWithComponents(components)
+    path = ""
+
+    for component in components do
+      path = self.sanitizePathComponent(path + "/" + self.sanitizePathComponent(component))
+    end
+
+    return path
+  end
+
+  :private
+
+  # Takes a path component and strips leading and trailing slashes
+  def self.sanitizePathComponent(component)
+    # Remove leading and trailing slash
+    component.gsub(/^\//, "").chomp("/")
+  end
+end

--- a/lib/second_curtain/upload.rb
+++ b/lib/second_curtain/upload.rb
@@ -2,6 +2,7 @@ require 'aws-sdk-v1'
 require 'date'
 require 'pathname'
 require 'uri'
+require 'second_curtain/path_utils'
 
 class Upload
   attr_reader :expected_path
@@ -19,12 +20,12 @@ class Upload
     abort unless path
 
     expected_filename = Pathname.new(@expected_path).basename.to_s
-    expected_object = bucket.objects[path + "/" + expected_filename]
+    expected_object = bucket.objects[PathUtils.pathWithComponents([path, expected_filename])]
     expected_object.write(:file => @expected_path)
     @uploaded_expected_url = expected_object.public_url
 
     actual_filename = Pathname.new(@actual_path).basename.to_s
-    actual_object = bucket.objects[path + "/" + actual_filename]
+    actual_object = bucket.objects[PathUtils.pathWithComponents([path, actual_filename])]
     actual_object.write(:file => @actual_path)
     @uploaded_actual_url = actual_object.public_url
   end

--- a/lib/second_curtain/upload_manager.rb
+++ b/lib/second_curtain/upload_manager.rb
@@ -1,6 +1,7 @@
 require 'aws-sdk-v1'
 require 'second_curtain/upload'
 require 'second_curtain/web_preview'
+require 'second_curtain/path_utils'
 
 class UploadManager
   def initialize (bucket, path_prefix)
@@ -24,7 +25,7 @@ class UploadManager
     end
 
     preview = WebPreview.new(@uploads)
-    index_object = @bucket.objects[@path_prefix + folder_name + "/index.html"]
+    index_object = @bucket.objects[PathUtils.pathWithComponents([@path_prefix, folder_name, "index.html"])]
     index_object.write(preview.generate_html)
     index_object.public_url.to_s
   end

--- a/spec/second_shutter/path_utils_spec.rb
+++ b/spec/second_shutter/path_utils_spec.rb
@@ -1,0 +1,32 @@
+require './lib/second_curtain/path_utils.rb'
+
+describe PathUtils do
+  before(:each) do
+  end
+
+  describe "composing a path" do
+    it "yields a concatenation of these components without leading and trailing slashes" do
+      expect(PathUtils.pathWithComponents(["component1", "component2"])).to eq("component1/component2")
+    end
+
+    it "yields a concatenation of these components without leading and trailing slashes" do
+      expect(PathUtils.pathWithComponents(["/component1/component1b/", "/component2/"])).to eq("component1/component1b/component2")
+    end
+
+    it "yields an empty string when called without components" do
+      expect(PathUtils.pathWithComponents([])).to eq("")
+    end
+
+    it "yields a string without leading slash when called with an empty first component" do
+      expect(PathUtils.pathWithComponents(["", "/component2"])).to eq("component2")
+    end
+
+    it "yields a string without trailing slash when called with an empty last component" do
+      expect(PathUtils.pathWithComponents(["component1", ""])).to eq("component1")
+    end
+
+    it "yields an empty string when called with a single slash" do
+      expect(PathUtils.pathWithComponents(["/"])).to eq("")
+    end
+  end
+end


### PR DESCRIPTION
Hi Ash,

While investigating #12, I found the following:

* `bucket.objects` expects a path without a leading /
* In some cases, too many slashes were added to a path in `Upload` and `UploadManager`, leading to the described bug

With this PR, I introduce `PathUtils`, a small class that allows you to build a path from components, ensuring that the end result does not contain leading and trailing slashes.

All tests still pass and the uploads work fine for me. There may be a Ruby standard-library function for this, but not that I am aware of 🤓