### PR TITLE
Reference images by filename only

### DIFF
--- a/lib/second_curtain/upload.rb
+++ b/lib/second_curtain/upload.rb
@@ -22,11 +22,11 @@ class Upload
     expected_filename = Pathname.new(@expected_path).basename.to_s
     expected_object = bucket.objects[PathUtils.pathWithComponents([path, expected_filename])]
     expected_object.write(:file => @expected_path)
-    @uploaded_expected_url = expected_object.public_url
+    @uploaded_expected_url = expected_filename
 
     actual_filename = Pathname.new(@actual_path).basename.to_s
     actual_object = bucket.objects[PathUtils.pathWithComponents([path, actual_filename])]
     actual_object.write(:file => @actual_path)
-    @uploaded_actual_url = actual_object.public_url
+    @uploaded_actual_url = actual_filename
   end
 end


### PR DESCRIPTION
In the current version, the HTML template references images by their public url, as retrieved from the AWS SDK through the property `public_url`. However, now that the images are stored in the same folder as `index.html`, they could be reference by their filename only.

A little backstory behind this PR: while we use Amazon S3 to store the snapshot image testing artefacts, we do not want them to be publicly available. Hence, we use a private bucket and only expose this bucket through a service that adds HTTP Basic Authentication. This won't work if images are referenced by their public path, as there is none in our case.
